### PR TITLE
make user-agent configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 var (
 	flAddr          string
 	flService       string
+	flUserAgent     string
 	flConnTimeout   time.Duration
 	flRPCTimeout    time.Duration
 	flTLS           bool
@@ -61,6 +62,7 @@ func init() {
 	log.SetFlags(0)
 	flag.StringVar(&flAddr, "addr", "", "(required) tcp host:port to connect")
 	flag.StringVar(&flService, "service", "", "service name to check (default: \"\")")
+	flag.StringVar(&flUserAgent, "user-agent", "grpc_health_probe", "user-agent header value of health check requests")
 	// timeouts
 	flag.DurationVar(&flConnTimeout, "connect-timeout", time.Second, "timeout for establishing connection")
 	flag.DurationVar(&flRPCTimeout, "rpc-timeout", time.Second, "timeout for health check rpc")
@@ -174,7 +176,7 @@ func main() {
 	}()
 
 	opts := []grpc.DialOption{
-		grpc.WithUserAgent("grpc_health_probe"),
+		grpc.WithUserAgent(flUserAgent),
 		grpc.WithBlock()}
 	if flTLS {
 		creds, err := buildCredentials(flTLSNoVerify, flTLSCACert, flTLSClientCert, flTLSClientKey, flTLSServerName)


### PR DESCRIPTION
I made `user-agent` configurable while its default value is the same as before `grpc_health_probe`.

If there is any concern, please let me know