### PR TITLE
Add http proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,6 @@
 module github.com/grpc-ecosystem/grpc-health-probe
 
-require google.golang.org/grpc v1.17.0
+require (
+	golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
+	google.golang.org/grpc v1.17.0
+)

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d h1:g9qWBGx4puODJTMVyoPrpoxPF
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20180830151530-49385e6e1522 h1:Ve1ORMCxvRmSXBwJK+t3Oy+V2vRW2OetUQBq4rJIkZE=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"time"
@@ -30,10 +31,14 @@ import (
 	"google.golang.org/grpc/credentials"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+
+	"golang.org/x/net/http2"
 )
 
-var (
+type ProbeConfig struct {
 	flAddr          string
+	flHTTPListenAddr string
+	flHTTPListenPath string
 	flService       string
 	flUserAgent     string
 	flConnTimeout   time.Duration
@@ -44,8 +49,31 @@ var (
 	flTLSClientCert string
 	flTLSClientKey  string
 	flTLSServerName string
+	flHTTPSTLSServerCert string
+	flHTTPSTLSServerKey string
+	flHTTPSTLSVerifyCA string
+	flHTTPSTLSVerifyClient bool
 	flVerbose       bool
+}
+
+var (
+	cfg = &ProbeConfig{}
 )
+
+type GrpcProbeError struct {
+	Code int
+    Message string
+}
+
+func NewGrpcProbeError(code int, message string) *GrpcProbeError {
+    return &GrpcProbeError{
+		Code: code,
+        Message: message,
+    }
+}
+func (e *GrpcProbeError) Error() string {
+    return e.Message
+}
 
 const (
 	// StatusInvalidArguments indicates specified invalid arguments.
@@ -60,20 +88,27 @@ const (
 
 func init() {
 	log.SetFlags(0)
-	flag.StringVar(&flAddr, "addr", "", "(required) tcp host:port to connect")
-	flag.StringVar(&flService, "service", "", "service name to check (default: \"\")")
-	flag.StringVar(&flUserAgent, "user-agent", "grpc_health_probe", "user-agent header value of health check requests")
+	flag.StringVar(&cfg.flAddr, "addr", "", "(required) tcp host:port to connect")
+	flag.StringVar(&cfg.flService, "service", "", "service name to check (default: \"\")")
+	flag.StringVar(&cfg.flUserAgent, "user-agent", "grpc_health_probe", "user-agent header value of health check requests")
+	// settings for HTTPS lisenter
+	flag.StringVar(&cfg.flHTTPListenAddr, "http-listen-addr", "", "http host:port to listen")
+	flag.StringVar(&cfg.flHTTPListenPath, "http-listen-path", "/", "path to listen for healthcheck traffic (default '/')")
+	flag.StringVar(&cfg.flHTTPSTLSServerCert, "https-listen-cert", "", "TLS Server certificate to for HTTP listner")
+	flag.StringVar(&cfg.flHTTPSTLSServerKey, "https-listen-key", "", "TLS Server certificate key to for HTTP listner")
+	flag.StringVar(&cfg.flHTTPSTLSVerifyCA, "https-listen-ca", "", "Use CA to verify client requests against CA")
+	flag.BoolVar(&cfg.flHTTPSTLSVerifyClient, "https-listen-verify", false, "Verify client certificate provided to the HTTP listner")
 	// timeouts
-	flag.DurationVar(&flConnTimeout, "connect-timeout", time.Second, "timeout for establishing connection")
-	flag.DurationVar(&flRPCTimeout, "rpc-timeout", time.Second, "timeout for health check rpc")
+	flag.DurationVar(&cfg.flConnTimeout, "connect-timeout", time.Second, "timeout for establishing connection")
+	flag.DurationVar(&cfg.flRPCTimeout, "rpc-timeout", time.Second, "timeout for health check rpc")
 	// tls settings
-	flag.BoolVar(&flTLS, "tls", false, "use TLS (default: false, INSECURE plaintext transport)")
-	flag.BoolVar(&flTLSNoVerify, "tls-no-verify", false, "(with -tls) don't verify the certificate (INSECURE) presented by the server (default: false)")
-	flag.StringVar(&flTLSCACert, "tls-ca-cert", "", "(with -tls, optional) file containing trusted certificates for verifying server")
-	flag.StringVar(&flTLSClientCert, "tls-client-cert", "", "(with -tls, optional) client certificate for authenticating to the server (requires -tls-client-key)")
-	flag.StringVar(&flTLSClientKey, "tls-client-key", "", "(with -tls) client private key for authenticating to the server (requires -tls-client-cert)")
-	flag.StringVar(&flTLSServerName, "tls-server-name", "", "(with -tls) override the hostname used to verify the server certificate")
-	flag.BoolVar(&flVerbose, "v", false, "verbose logs")
+	flag.BoolVar(&cfg.flTLS, "tls", false, "use TLS (default: false, INSECURE plaintext transport)")
+	flag.BoolVar(&cfg.flTLSNoVerify, "tls-no-verify", false, "(with -tls) don't verify the certificate (INSECURE) presented by the server (default: false)")
+	flag.StringVar(&cfg.flTLSCACert, "tls-ca-cert", "", "(with -tls, optional) file containing trusted certificates for verifying server")
+	flag.StringVar(&cfg.flTLSClientCert, "tls-client-cert", "", "(with -tls, optional) client certificate for authenticating to the server (requires -tls-client-key)")
+	flag.StringVar(&cfg.flTLSClientKey, "tls-client-key", "", "(with -tls) client private key for authenticating to the server (requires -tls-client-cert)")
+	flag.StringVar(&cfg.flTLSServerName, "tls-server-name", "", "(with -tls) override the hostname used to verify the server certificate")
+	flag.BoolVar(&cfg.flVerbose, "v", false, "verbose logs")
 
 	flag.Parse()
 
@@ -82,50 +117,66 @@ func init() {
 		os.Exit(StatusInvalidArguments)
 	}
 
-	if flAddr == "" {
+	if cfg.flAddr == "" {
 		argError("-addr not specified")
 	}
-	if flConnTimeout <= 0 {
-		argError("-connect-timeout must be greater than zero (specified: %v)", flConnTimeout)
+	if cfg.flConnTimeout <= 0 {
+		argError("-connect-timeout must be greater than zero (specified: %v)", cfg.flConnTimeout)
 	}
-	if flRPCTimeout <= 0 {
-		argError("-rpc-timeout must be greater than zero (specified: %v)", flRPCTimeout)
+	if cfg.flRPCTimeout <= 0 {
+		argError("-rpc-timeout must be greater than zero (specified: %v)", cfg.flRPCTimeout)
 	}
-	if !flTLS && flTLSNoVerify {
+	if !cfg.flTLS && cfg.flTLSNoVerify {
 		argError("specified -tls-no-verify without specifying -tls")
 	}
-	if !flTLS && flTLSCACert != "" {
+	if !cfg.flTLS && cfg.flTLSCACert != "" {
 		argError("specified -tls-ca-cert without specifying -tls")
 	}
-	if !flTLS && flTLSClientCert != "" {
+	if !cfg.flTLS && cfg.flTLSClientCert != "" {
 		argError("specified -tls-client-cert without specifying -tls")
 	}
-	if !flTLS && flTLSServerName != "" {
+	if !cfg.flTLS && cfg.flTLSServerName != "" {
 		argError("specified -tls-server-name without specifying -tls")
 	}
-	if flTLSClientCert != "" && flTLSClientKey == "" {
+	if cfg.flTLSClientCert != "" && cfg.flTLSClientKey == "" {
 		argError("specified -tls-client-cert without specifying -tls-client-key")
 	}
-	if flTLSClientCert == "" && flTLSClientKey != "" {
+	if cfg.flTLSClientCert == "" && cfg.flTLSClientKey != "" {
 		argError("specified -tls-client-key without specifying -tls-client-cert")
 	}
-	if flTLSNoVerify && flTLSCACert != "" {
+	if cfg.flTLSNoVerify && cfg.flTLSCACert != "" {
 		argError("cannot specify -tls-ca-cert with -tls-no-verify (CA cert would not be used)")
 	}
-	if flTLSNoVerify && flTLSServerName != "" {
+	if cfg.flTLSNoVerify && cfg.flTLSServerName != "" {
 		argError("cannot specify -tls-server-name with -tls-no-verify (server name would not be used)")
 	}
+	if ((cfg.flHTTPSTLSServerCert != "" || cfg.flHTTPSTLSServerKey != "" || cfg.flHTTPSTLSVerifyClient ) &&  cfg.flHTTPListenAddr == "" ) {
+		argError("cannot specify -https-listen-cert or https-listen-key if -http-listen-addr is not set (no https server would be listening)")
+	}
+	if cfg.flHTTPSTLSVerifyCA == "" && cfg.flHTTPSTLSVerifyClient {
+		argError("cannot specify -https-listen-ca if https-listen-verify is set (you need a trust CA for client certificate https auth)")
+	}
 
-	if flVerbose {
+	if cfg.flVerbose {
 		log.Printf("parsed options:")
-		log.Printf("> addr=%s conn_timeout=%v rpc_timeout=%v", flAddr, flConnTimeout, flRPCTimeout)
-		log.Printf("> tls=%v", flTLS)
-		if flTLS {
-			log.Printf("  > no-verify=%v ", flTLSNoVerify)
-			log.Printf("  > ca-cert=%s", flTLSCACert)
-			log.Printf("  > client-cert=%s", flTLSClientCert)
-			log.Printf("  > client-key=%s", flTLSClientKey)
-			log.Printf("  > server-name=%s", flTLSServerName)
+		log.Printf("> addr=%s conn_timeout=%v rpc_timeout=%v", cfg.flAddr, cfg.flConnTimeout, cfg.flRPCTimeout)
+		log.Printf("> tls=%v", cfg.flTLS)
+		if cfg.flHTTPListenAddr != "" {
+			log.Printf(" http-listen-addr=%v ", cfg.flHTTPListenAddr)
+			log.Printf(" http-listen-path=%v ", cfg.flHTTPListenPath)
+		}
+		if cfg.flHTTPSTLSServerCert !="" {
+			log.Printf(" https-listen-cert=%v ", cfg.flHTTPSTLSServerCert)
+			log.Printf(" https-listen-key=%v ", cfg.flHTTPSTLSServerKey)
+			log.Printf(" https-listen-verify=%v ", cfg.flHTTPSTLSVerifyClient)
+			log.Printf(" https-listen-ca=%v ", cfg.flHTTPSTLSVerifyCA)
+		}
+		if cfg.flTLS {
+			log.Printf("  > no-verify=%v ", cfg.flTLSNoVerify)
+			log.Printf("  > ca-cert=%s", cfg.flTLSCACert)
+			log.Printf("  > client-cert=%s", cfg.flTLSClientCert)
+			log.Printf("  > client-key=%s", cfg.flTLSClientKey)
+			log.Printf("  > server-name=%s", cfg.flTLSServerName)
 		}
 	}
 }
@@ -161,6 +212,93 @@ func buildCredentials(skipVerify bool, caCerts, clientCert, clientKey, serverNam
 	return credentials.NewTLS(&cfg), nil
 }
 
+func checkService(ctx context.Context) (healthpb.HealthCheckResponse_ServingStatus, error) {
+	opts := []grpc.DialOption{
+		grpc.WithUserAgent(cfg.flUserAgent),
+		grpc.WithBlock()}
+	if cfg.flTLS {
+		creds, err := buildCredentials(cfg.flTLSNoVerify, cfg.flTLSCACert, cfg.flTLSClientCert, cfg.flTLSClientKey, cfg.flTLSServerName)
+		if err != nil {
+			log.Printf("failed to initialize tls credentials. error=%v", err)
+			os.Exit(StatusInvalidArguments)
+		}
+		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithInsecure())
+	}
+
+	if cfg.flVerbose {
+		log.Print("establishing connection")
+	}
+	connStart := time.Now()
+	dialCtx, cancel2 := context.WithTimeout(ctx, cfg.flConnTimeout)
+	defer cancel2()
+	conn, err := grpc.DialContext(dialCtx, cfg.flAddr, opts...)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			log.Printf("timeout: failed to connect service %q within %v", cfg.flAddr, cfg.flConnTimeout)
+		} else {
+			log.Printf("error: failed to connect service at %q: %+v", cfg.flAddr, err)
+		}
+		return healthpb.HealthCheckResponse_UNKNOWN, NewGrpcProbeError(StatusConnectionFailure, "StatusConnectionFailure")
+	}
+	connDuration := time.Since(connStart)
+	defer conn.Close()
+	if cfg.flVerbose {
+		log.Printf("connection established (took %v)", connDuration)
+	}
+
+	rpcStart := time.Now()
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, cfg.flRPCTimeout)
+	defer rpcCancel()
+	resp, err := healthpb.NewHealthClient(conn).Check(rpcCtx, &healthpb.HealthCheckRequest{Service: cfg.flService})
+	if err != nil {
+		if stat, ok := status.FromError(err); ok && stat.Code() == codes.Unimplemented {
+			log.Printf("error: this server does not implement the grpc health protocol (grpc.health.v1.Health)")
+		} else if stat, ok := status.FromError(err); ok && stat.Code() == codes.DeadlineExceeded {
+			log.Printf("timeout: health rpc did not complete within %v", cfg.flRPCTimeout)
+		} else {
+			log.Printf("error: health rpc failed: %+v", err)
+		}
+		return healthpb.HealthCheckResponse_UNKNOWN, NewGrpcProbeError(StatusRPCFailure, "StatusRPCFailure")
+	}
+	rpcDuration := time.Since(rpcStart)
+
+	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
+		log.Printf("service unhealthy (responded with %q)", resp.GetStatus().String())
+		return healthpb.HealthCheckResponse_NOT_SERVING, NewGrpcProbeError(StatusUnhealthy, "StatusUnhealthy")
+	}
+	if cfg.flVerbose {
+		log.Printf("time elapsed: connect=%v rpc=%v", connDuration, rpcDuration)
+	}
+	return resp.GetStatus(), nil
+}
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	resp, err := checkService(r.Context())
+	if err != nil {
+        if pe, ok := err.(*GrpcProbeError); ok {
+			log.Printf("HealtCheck Probe Error: %v", pe.Error())
+			switch pe.Code {
+			case StatusUnhealthy:
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			case StatusConnectionFailure:
+				http.Error(w, err.Error(), http.StatusBadGateway)
+			case StatusRPCFailure:
+				http.Error(w, err.Error(), http.StatusBadGateway)
+			default:
+				http.Error(w, err.Error(), http.StatusBadGateway)
+			}
+			http.Error(w, err.Error(), http.StatusBadGateway)
+		}
+	}
+	if cfg.flVerbose {
+		log.Printf("status: %v", resp.String())
+	}
+	fmt.Fprintf(w, "status: %v", resp.String())
+}
+
+
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -171,67 +309,51 @@ func main() {
 		if sig == os.Interrupt {
 			log.Printf("cancellation received")
 			cancel()
-			return
+			os.Exit(0)
 		}
 	}()
 
-	opts := []grpc.DialOption{
-		grpc.WithUserAgent(flUserAgent),
-		grpc.WithBlock()}
-	if flTLS {
-		creds, err := buildCredentials(flTLSNoVerify, flTLSCACert, flTLSClientCert, flTLSClientKey, flTLSServerName)
+	if (cfg.flHTTPListenAddr != "") {
+		tlsConfig := &tls.Config{}
+		if (cfg.flHTTPSTLSVerifyClient) {
+			caCert, err := ioutil.ReadFile(cfg.flHTTPSTLSVerifyCA)
+			if err != nil {
+				log.Fatal(err)
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+
+			tlsConfig = &tls.Config{
+				ClientCAs: caCertPool,
+				ClientAuth: tls.RequireAndVerifyClientCert,
+			}
+		}
+		tlsConfig.BuildNameToCertificate()
+
+		srv := &http.Server{
+			Addr: cfg.flHTTPListenAddr,
+			TLSConfig: tlsConfig,
+		}
+		http2.ConfigureServer(srv, &http2.Server{})
+		http.HandleFunc(cfg.flHTTPListenPath, healthHandler)
+
+		var err error
+		if (cfg.flHTTPSTLSServerCert != "" && cfg.flHTTPSTLSServerKey != "" ) {
+			err = srv.ListenAndServeTLS(cfg.flHTTPSTLSServerCert, cfg.flHTTPSTLSServerKey)
+		} else {
+			err = srv.ListenAndServe()
+		}
 		if err != nil {
-			log.Printf("failed to initialize tls credentials. error=%v", err)
-			os.Exit(StatusInvalidArguments)
+			log.Fatal("ListenAndServe Error: ", err)
 		}
-		opts = append(opts, grpc.WithTransportCredentials(creds))
-	} else {
-		opts = append(opts, grpc.WithInsecure())
 	}
-
-	if flVerbose {
-		log.Print("establishing connection")
-	}
-	connStart := time.Now()
-	dialCtx, cancel2 := context.WithTimeout(ctx, flConnTimeout)
-	defer cancel2()
-	conn, err := grpc.DialContext(dialCtx, flAddr, opts...)
+	resp, err := checkService(ctx)
 	if err != nil {
-		if err == context.DeadlineExceeded {
-			log.Printf("timeout: failed to connect service %q within %v", flAddr, flConnTimeout)
-		} else {
-			log.Printf("error: failed to connect service at %q: %+v", flAddr, err)
+        if pe, ok := err.(*GrpcProbeError); ok {
+			log.Printf("HealtCheck Probe Error: %v", pe.Error())
+			os.Exit(pe.Code)
 		}
-		os.Exit(StatusConnectionFailure)
+		os.Exit(1)
 	}
-	connDuration := time.Since(connStart)
-	defer conn.Close()
-	if flVerbose {
-		log.Printf("connection establisted (took %v)", connDuration)
-	}
-
-	rpcStart := time.Now()
-	rpcCtx, rpcCancel := context.WithTimeout(ctx, flRPCTimeout)
-	defer rpcCancel()
-	resp, err := healthpb.NewHealthClient(conn).Check(rpcCtx, &healthpb.HealthCheckRequest{Service: flService})
-	if err != nil {
-		if stat, ok := status.FromError(err); ok && stat.Code() == codes.Unimplemented {
-			log.Printf("error: this server does not implement the grpc health protocol (grpc.health.v1.Health)")
-		} else if stat, ok := status.FromError(err); ok && stat.Code() == codes.DeadlineExceeded {
-			log.Printf("timeout: health rpc did not complete within %v", flRPCTimeout)
-		} else {
-			log.Printf("error: health rpc failed: %+v", err)
-		}
-		os.Exit(StatusRPCFailure)
-	}
-	rpcDuration := time.Since(rpcStart)
-
-	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
-		log.Printf("service unhealthy (responded with %q)", resp.GetStatus().String())
-		os.Exit(StatusUnhealthy)
-	}
-	if flVerbose {
-		log.Printf("time elapsed: connect=%v rpc=%v", connDuration, rpcDuration)
-	}
-	log.Printf("status: %v", resp.GetStatus().String())
+	log.Printf("status: %v", resp.String())
 }


### PR DESCRIPTION
Currently, `grpc-health-probe` runs as executable, checks the health status and shuts down.  

With this change a user can optionally start `grpc-health-probe` as an http server which accepts an http based healthcheck request.  For each request a grpc-native healthcheck is issued for an upstream service.  The repsonse status of the grpc serivce is returned back to the original http client request.

- http listener supports  `http`, `https`, `mTLS`

Usage:

- Check the status of an upstream gRPC serviceName `echo.EchoService` listening on `:50051`:

```text
$ grpc_health_probe --addr localhost:50051 \
                    --service echo.EchoServer
```

- HTTP to gRPC HealthCheck proxy:

`grpc_health_probe` will listen on `:8080` for HTTP healthcheck requests at path `/healthz`.

```text
$ grpc_health_probe --http-listen-addr localhost:8080 \
                    --http-listen-path /healthz \
                    --addr localhost:50051 \
                    --service echo.EchoServer
```

- HTTPS to gRPC HealthCheck proxy:

`grpc_health_probe` will listen on `:8080` for HTTPS healthcheck requests at path `/healthz`.

HTTPS listener will use keypairs [server_crt.pem, server_crt.pem]

```text
$ grpc_health_probe --http-listen-addr localhost:8080 \
                    --http-listen-path /heatlhz \
                    --addr localhost:50051 \
                    --https-listen-cert server_crt.pem \
                    --https-listen-key server_key.pem \
                    --service echo.EchoServer
```

- mTLS HTTPS to gRPC HealthCheck proxy:

`grpc_health_probe` will listen on `:8080` for HTTPS with mTLS healthcheck requests at path `/healthz`.

HTTPS listener will use keypairs [server_crt.pem, server_crt.pem] and verify client certificates issued by `CA_crt.pem`

```text
$ grpc_health_probe --http-listen-addr localhost:8080 \
                    --http-listen-path /healthz \
                    --addr localhost:50051 \
                    --https-listen-cert server_crt.pem \
                    --https-listen-key server_key.pem \
                    --service echo.EchoServer \
                    --https-listen-verify \
                    --https-listen-ca=CA_crt.pem
```


