### PR TITLE
 Add the ability to specify metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/grpc-ecosystem/grpc-health-probe
 
 require google.golang.org/grpc v1.17.0
+require "github.com/spf13/pflag" v1.0.3

--- a/main.go
+++ b/main.go
@@ -14,8 +14,6 @@
 package main
 
 import (
-	"google.golang.org/grpc/metadata"
-	"strings"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -24,11 +22,13 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 

--- a/main.go
+++ b/main.go
@@ -132,7 +132,7 @@ func init() {
 	if flVerbose {
 		log.Printf("parsed options:")
 		log.Printf("> addr=%s conn_timeout=%v rpc_timeout=%v", flAddr, flConnTimeout, flRPCTimeout)
-		log.Printf("> metadta=%v", flMetadata)
+		log.Printf("> metadata=%v", flMetadata)
 		log.Printf("> tls=%v", flTLS)
 		if flTLS {
 			log.Printf("  > no-verify=%v ", flTLSNoVerify)


### PR DESCRIPTION
We have a use case where we need to send custom metadata to the server for the health check. This change enables specifying metadata on the command line.