### PR TITLE
Bump Docker base image to golang:1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS build
+FROM golang:1.13 AS build
 ENV PROJECT grpc_health_probe
 WORKDIR /src/$PROJECT
 COPY go.mod go.sum ./


### PR DESCRIPTION
To fix CVEs and have it up to date in general.