### PR TITLE
Documentation update: Added other available flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ with command-line options:
 | **`-tls-no-verify`** | use TLS, but do not verify the certificate presented by the server (INSECURE) (default: false) |
 | **`-tls-server-name`** | override the hostname used to verify the server certificate |
 
+## Other Available Flags
+
+| Option | Description |
+|:------------|-------------|
+| **`-v`**    | verbose logs (default: false) |
+| **`-connect-timeout`** | timeout for establishing connection |
+| **`-rpc-timeout`** | timeout for health check rpc |
+| **`-user-agent`** | user-agent header value of health check requests (default: grpc_health_probe) |
+| **`-service`** | service name to check (default: "") - empty string is convention for server health |
+
 **Example:**
 
 1. Start the `route_guide` [example


### PR DESCRIPTION
I'm using your tool and had to go to main to find the server flag. Thought a documentation update with the other flags you've built in would be useful to others.