### PR TITLE
Support only-connect mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ spec:
       initialDelaySeconds: 5
     livenessProbe:
       exec:
-        command: ["/bin/grpc_health_probe", "-addr=:5000"]
+        command: ["/bin/grpc_health_probe", "-addr=:5000", "-only-connect"]
       initialDelaySeconds: 10
 ```
 
@@ -125,6 +125,7 @@ with command-line options:
 | **`-connect-timeout`** | timeout for establishing connection |
 | **`-rpc-timeout`** | timeout for health check rpc |
 | **`-user-agent`** | user-agent header value of health check requests (default: grpc_health_probe) |
+| **`-only-connect`** | check only the connection (default: false) |
 | **`-service`** | service name to check (default: "") - empty string is convention for server health |
 | **`-gzip`** | use GZIPCompressor for requests and GZIPDecompressor for response (default: false) |
 

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ var (
 	flAddr          string
 	flService       string
 	flUserAgent     string
+	flOnlyConnect   bool
 	flConnTimeout   time.Duration
 	flRPCTimeout    time.Duration
 	flTLS           bool
@@ -65,6 +66,7 @@ func init() {
 	flagSet.StringVar(&flAddr, "addr", "", "(required) tcp host:port to connect")
 	flagSet.StringVar(&flService, "service", "", "service name to check (default: \"\")")
 	flagSet.StringVar(&flUserAgent, "user-agent", "grpc_health_probe", "user-agent header value of health check requests")
+	flagSet.BoolVar(&flOnlyConnect, "only-connect", false, "check only the connection (default: false)")
 	// timeouts
 	flagSet.DurationVar(&flConnTimeout, "connect-timeout", time.Second, "timeout for establishing connection")
 	flagSet.DurationVar(&flRPCTimeout, "rpc-timeout", time.Second, "timeout for health check rpc")
@@ -227,6 +229,9 @@ func main() {
 	defer conn.Close()
 	if flVerbose {
 		log.Printf("connection established (took %v)", connDuration)
+	}
+	if flOnlyConnect {
+		return
 	}
 
 	rpcStart := time.Now()


### PR DESCRIPTION
To avoid unexpected container restarting on heavy traffic in a Kubernetes cluster, we need to check a connection with the gRPC server instead of calling an RPC because it won't be get executed because of the heavy traffic. In that situation, the exit code of this tool becomes `3`, and it's not handled as success in a Kubernetes probe, then it triggers container restarting and abort some executing and queuing requests. So far, I wrote the following probes to ignore this exit code, but I think we should have an only-connect mode to reduce the number of lines of our manifests.

```yaml
readinessProbe:
  exec:
    command:
    - grpc_health_probe -addr=localhost:5000
livenessProbe:
  exec:
    command:
    - sh
    - -c
    - |
      grpc_health_probe -addr=localhost:5000 -rpc-timeout=1s
      ret=$?
      test $ret -eq 0 || test $ret -ge 3
```

With this PR, the same approach will be,

```yaml
readinessProbe:
  exec:
    command:
    - grpc_health_probe -addr=localhost:5000
livenessProbe:
  exec:
    command:
    - grpc_health_probe -addr=localhost:5000 --only-connect
```


I didn't come up with a better name than `only-connect`, but please give me a suggestion.