### PR TITLE
Add a simple test

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,23 +37,25 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var (
-	flAddr          string
-	flService       string
-	flUserAgent     string
-	flConnTimeout   time.Duration
-	flRPCHeaders    = rpcHeaders{MD: make(metadata.MD)}
-	flRPCTimeout    time.Duration
-	flTLS           bool
-	flTLSNoVerify   bool
-	flTLSCACert     string
-	flTLSClientCert string
-	flTLSClientKey  string
-	flTLSServerName string
-	flVerbose       bool
-	flGZIP          bool
-	flSPIFFE        bool
-)
+type Flags struct {
+	Addr          string
+	Service       string
+	UserAgent     string
+	ConnTimeout   time.Duration
+	RPCHeaders    rpcHeaders
+	RPCTimeout    time.Duration
+	TLS           bool
+	TLSNoVerify   bool
+	TLSCACert     string
+	TLSClientCert string
+	TLSClientKey  string
+	TLSServerName string
+	Verbose       bool
+	GZIP          bool
+	SPIFFE        bool
+}
+
+var fl Flags
 
 const (
 	// StatusInvalidArguments indicates specified invalid arguments.
@@ -68,87 +70,84 @@ const (
 	StatusSpiffeFailed = 20
 )
 
-func init() {
+func parseFlags(args []string) error {
 	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
+	fl = Flags{}
 	log.SetFlags(0)
-	flagSet.StringVar(&flAddr, "addr", "", "(required) tcp host:port to connect")
-	flagSet.StringVar(&flService, "service", "", "service name to check (default: \"\")")
-	flagSet.StringVar(&flUserAgent, "user-agent", "grpc_health_probe", "user-agent header value of health check requests")
+	flagSet.StringVar(&fl.Addr, "addr", "", "(required) tcp host:port to connect")
+	flagSet.StringVar(&fl.Service, "service", "", "service name to check (default: \"\")")
+	flagSet.StringVar(&fl.UserAgent, "user-agent", "grpc_health_probe", "user-agent header value of health check requests")
+	flagSet.Var(&fl.RPCHeaders, "rpc-header", "additional RPC headers in 'name: value' format. May specify more than one via multiple flags.")
 	// timeouts
-	flagSet.DurationVar(&flConnTimeout, "connect-timeout", time.Second, "timeout for establishing connection")
-	flagSet.Var(&flRPCHeaders, "rpc-header", "additional RPC headers in 'name: value' format. May specify more than one via multiple flags.")
-	flagSet.DurationVar(&flRPCTimeout, "rpc-timeout", time.Second, "timeout for health check rpc")
+	flagSet.DurationVar(&fl.ConnTimeout, "connect-timeout", time.Second, "timeout for establishing connection")
+	flagSet.DurationVar(&fl.RPCTimeout, "rpc-timeout", time.Second, "timeout for health check rpc")
 	// tls settings
-	flagSet.BoolVar(&flTLS, "tls", false, "use TLS (default: false, INSECURE plaintext transport)")
-	flagSet.BoolVar(&flTLSNoVerify, "tls-no-verify", false, "(with -tls) don't verify the certificate (INSECURE) presented by the server (default: false)")
-	flagSet.StringVar(&flTLSCACert, "tls-ca-cert", "", "(with -tls, optional) file containing trusted certificates for verifying server")
-	flagSet.StringVar(&flTLSClientCert, "tls-client-cert", "", "(with -tls, optional) client certificate for authenticating to the server (requires -tls-client-key)")
-	flagSet.StringVar(&flTLSClientKey, "tls-client-key", "", "(with -tls) client private key for authenticating to the server (requires -tls-client-cert)")
-	flagSet.StringVar(&flTLSServerName, "tls-server-name", "", "(with -tls) override the hostname used to verify the server certificate")
-	flagSet.BoolVar(&flVerbose, "v", false, "verbose logs")
-	flagSet.BoolVar(&flGZIP, "gzip", false, "use GZIPCompressor for requests and GZIPDecompressor for response (default: false)")
-	flagSet.BoolVar(&flSPIFFE, "spiffe", false, "use SPIFFE to obtain mTLS credentials")
+	flagSet.BoolVar(&fl.TLS, "tls", false, "use TLS (default: false, INSECURE plaintext transport)")
+	flagSet.BoolVar(&fl.TLSNoVerify, "tls-no-verify", false, "(with -tls) don't verify the certificate (INSECURE) presented by the server (default: false)")
+	flagSet.StringVar(&fl.TLSCACert, "tls-ca-cert", "", "(with -tls, optional) file containing trusted certificates for verifying server")
+	flagSet.StringVar(&fl.TLSClientCert, "tls-client-cert", "", "(with -tls, optional) client certificate for authenticating to the server (requires -tls-client-key)")
+	flagSet.StringVar(&fl.TLSClientKey, "tls-client-key", "", "(with -tls) client private key for authenticating to the server (requires -tls-client-cert)")
+	flagSet.StringVar(&fl.TLSServerName, "tls-server-name", "", "(with -tls) override the hostname used to verify the server certificate")
+	flagSet.BoolVar(&fl.Verbose, "v", false, "verbose logs")
+	flagSet.BoolVar(&fl.GZIP, "gzip", false, "use GZIPCompressor for requests and GZIPDecompressor for response (default: false)")
+	flagSet.BoolVar(&fl.SPIFFE, "spiffe", false, "use SPIFFE to obtain mTLS credentials")
 
-	err := flagSet.Parse(os.Args[1:])
+	err := flagSet.Parse(args)
 	if err != nil {
-		os.Exit(StatusInvalidArguments)
+		return err
 	}
 
-	argError := func(s string, v ...interface{}) {
-		log.Printf("error: "+s, v...)
-		os.Exit(StatusInvalidArguments)
+	if fl.Addr == "" {
+		return fmt.Errorf("-addr not specified")
+	}
+	if fl.ConnTimeout <= 0 {
+		return fmt.Errorf("-connect-timeout must be greater than zero (specified: %v)", fl.ConnTimeout)
+	}
+	if fl.RPCTimeout <= 0 {
+		return fmt.Errorf("-rpc-timeout must be greater than zero (specified: %v)", fl.RPCTimeout)
+	}
+	if !fl.TLS && fl.TLSNoVerify {
+		return fmt.Errorf("specified -tls-no-verify without specifying -tls")
+	}
+	if !fl.TLS && fl.TLSCACert != "" {
+		return fmt.Errorf("specified -tls-ca-cert without specifying -tls")
+	}
+	if !fl.TLS && fl.TLSClientCert != "" {
+		return fmt.Errorf("specified -tls-client-cert without specifying -tls")
+	}
+	if !fl.TLS && fl.TLSServerName != "" {
+		return fmt.Errorf("specified -tls-server-name without specifying -tls")
+	}
+	if fl.TLSClientCert != "" && fl.TLSClientKey == "" {
+		return fmt.Errorf("specified -tls-client-cert without specifying -tls-client-key")
+	}
+	if fl.TLSClientCert == "" && fl.TLSClientKey != "" {
+		return fmt.Errorf("specified -tls-client-key without specifying -tls-client-cert")
+	}
+	if fl.TLSNoVerify && fl.TLSCACert != "" {
+		return fmt.Errorf("cannot specify -tls-ca-cert with -tls-no-verify (CA cert would not be used)")
+	}
+	if fl.TLSNoVerify && fl.TLSServerName != "" {
+		return fmt.Errorf("cannot specify -tls-server-name with -tls-no-verify (server name would not be used)")
 	}
 
-	if flAddr == "" {
-		argError("-addr not specified")
-	}
-	if flConnTimeout <= 0 {
-		argError("-connect-timeout must be greater than zero (specified: %v)", flConnTimeout)
-	}
-	if flRPCTimeout <= 0 {
-		argError("-rpc-timeout must be greater than zero (specified: %v)", flRPCTimeout)
-	}
-	if !flTLS && flTLSNoVerify {
-		argError("specified -tls-no-verify without specifying -tls")
-	}
-	if !flTLS && flTLSCACert != "" {
-		argError("specified -tls-ca-cert without specifying -tls")
-	}
-	if !flTLS && flTLSClientCert != "" {
-		argError("specified -tls-client-cert without specifying -tls")
-	}
-	if !flTLS && flTLSServerName != "" {
-		argError("specified -tls-server-name without specifying -tls")
-	}
-	if flTLSClientCert != "" && flTLSClientKey == "" {
-		argError("specified -tls-client-cert without specifying -tls-client-key")
-	}
-	if flTLSClientCert == "" && flTLSClientKey != "" {
-		argError("specified -tls-client-key without specifying -tls-client-cert")
-	}
-	if flTLSNoVerify && flTLSCACert != "" {
-		argError("cannot specify -tls-ca-cert with -tls-no-verify (CA cert would not be used)")
-	}
-	if flTLSNoVerify && flTLSServerName != "" {
-		argError("cannot specify -tls-server-name with -tls-no-verify (server name would not be used)")
-	}
-
-	if flVerbose {
+	if fl.Verbose {
 		log.Printf("parsed options:")
-		log.Printf("> addr=%s conn_timeout=%v rpc_timeout=%v", flAddr, flConnTimeout, flRPCTimeout)
-		if flRPCHeaders.Len() > 0 {
-			log.Printf("> headers: %s", flRPCHeaders)
+		log.Printf("> addr=%s conn_timeout=%v rpc_timeout=%v", fl.Addr, fl.ConnTimeout, fl.RPCTimeout)
+		if fl.RPCHeaders.Len() > 0 {
+			log.Printf("> headers: %s", fl.RPCHeaders)
 		}
-		log.Printf("> tls=%v", flTLS)
-		if flTLS {
-			log.Printf("  > no-verify=%v ", flTLSNoVerify)
-			log.Printf("  > ca-cert=%s", flTLSCACert)
-			log.Printf("  > client-cert=%s", flTLSClientCert)
-			log.Printf("  > client-key=%s", flTLSClientKey)
-			log.Printf("  > server-name=%s", flTLSServerName)
+		log.Printf("> tls=%v", fl.TLS)
+		if fl.TLS {
+			log.Printf("  > no-verify=%v ", fl.TLSNoVerify)
+			log.Printf("  > ca-cert=%s", fl.TLSCACert)
+			log.Printf("  > client-cert=%s", fl.TLSClientCert)
+			log.Printf("  > client-key=%s", fl.TLSClientKey)
+			log.Printf("  > server-name=%s", fl.TLSServerName)
 		}
-		log.Printf("> spiffe=%v", flSPIFFE)
+		log.Printf("> spiffe=%v", fl.SPIFFE)
 	}
+	return nil
 }
 
 type rpcHeaders struct{ metadata.MD }
@@ -156,6 +155,9 @@ type rpcHeaders struct{ metadata.MD }
 func (s *rpcHeaders) String() string { return fmt.Sprintf("%v", s.MD) }
 
 func (s *rpcHeaders) Set(value string) error {
+	if s.MD == nil {
+		s.MD = make(metadata.MD)
+	}
 	parts := strings.SplitN(value, ":", 2)
 	if len(parts) != 2 {
 		return fmt.Errorf("invalid RPC header, expected 'key: value', got %q", value)
@@ -196,10 +198,11 @@ func buildCredentials(skipVerify bool, caCerts, clientCert, clientKey, serverNam
 	return credentials.NewTLS(&cfg), nil
 }
 
-func main() {
-	retcode := 0
-	defer func() { os.Exit(retcode) }()
-
+func probe(args ...string) int {
+	if err := parseFlags(args); err != nil {
+		log.Printf("error: %v", err)
+		return StatusInvalidArguments
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := make(chan os.Signal, 1)
@@ -214,31 +217,28 @@ func main() {
 	}()
 
 	opts := []grpc.DialOption{
-		grpc.WithUserAgent(flUserAgent),
+		grpc.WithUserAgent(fl.UserAgent),
 		grpc.WithBlock(),
 	}
-	if flTLS && flSPIFFE {
+	if fl.TLS && fl.SPIFFE {
 		log.Printf("-tls and -spiffe are mutually incompatible")
-		retcode = StatusInvalidArguments
-		return
+		return StatusInvalidArguments
 	}
-	if flTLS {
-		creds, err := buildCredentials(flTLSNoVerify, flTLSCACert, flTLSClientCert, flTLSClientKey, flTLSServerName)
+	if fl.TLS {
+		creds, err := buildCredentials(fl.TLSNoVerify, fl.TLSCACert, fl.TLSClientCert, fl.TLSClientKey, fl.TLSServerName)
 		if err != nil {
 			log.Printf("failed to initialize tls credentials. error=%v", err)
-			retcode = StatusInvalidArguments
-			return
+			return StatusInvalidArguments
 		}
 		opts = append(opts, grpc.WithTransportCredentials(creds))
-	} else if flSPIFFE {
-		spiffeCtx, _ := context.WithTimeout(ctx, flRPCTimeout)
+	} else if fl.SPIFFE {
+		spiffeCtx, _ := context.WithTimeout(ctx, fl.RPCTimeout)
 		source, err := workloadapi.NewX509Source(spiffeCtx)
 		if err != nil {
 			log.Printf("failed to initialize tls credentials with spiffe. error=%v", err)
-			retcode = StatusSpiffeFailed
-			return
+			return StatusSpiffeFailed
 		}
-		if flVerbose {
+		if fl.Verbose {
 			svid, err := source.GetX509SVID()
 			if err != nil {
 				log.Fatalf("error getting x509 svid: %+v", err)
@@ -251,62 +251,64 @@ func main() {
 		opts = append(opts, grpc.WithInsecure())
 	}
 
-	if flGZIP {
+	if fl.GZIP {
 		opts = append(opts,
 			grpc.WithCompressor(grpc.NewGZIPCompressor()),
 			grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
 		)
 	}
 
-	if flVerbose {
+	if fl.Verbose {
 		log.Print("establishing connection")
 	}
 	connStart := time.Now()
-	dialCtx, dialCancel := context.WithTimeout(ctx, flConnTimeout)
+	dialCtx, dialCancel := context.WithTimeout(ctx, fl.ConnTimeout)
 	defer dialCancel()
-	conn, err := grpc.DialContext(dialCtx, flAddr, opts...)
+	conn, err := grpc.DialContext(dialCtx, fl.Addr, opts...)
 	if err != nil {
 		if err == context.DeadlineExceeded {
-			log.Printf("timeout: failed to connect service %q within %v", flAddr, flConnTimeout)
+			log.Printf("timeout: failed to connect service %q within %v", fl.Addr, fl.ConnTimeout)
 		} else {
-			log.Printf("error: failed to connect service at %q: %+v", flAddr, err)
+			log.Printf("error: failed to connect service at %q: %+v", fl.Addr, err)
 		}
-		retcode = StatusConnectionFailure
-		return
+		return StatusConnectionFailure
 	}
 	connDuration := time.Since(connStart)
 	defer conn.Close()
-	if flVerbose {
+	if fl.Verbose {
 		log.Printf("connection established (took %v)", connDuration)
 	}
 
 	rpcStart := time.Now()
-	rpcCtx, rpcCancel := context.WithTimeout(ctx, flRPCTimeout)
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, fl.RPCTimeout)
 	defer rpcCancel()
-	rpcCtx = metadata.NewOutgoingContext(ctx, flRPCHeaders.MD)
+	rpcCtx = metadata.NewOutgoingContext(ctx, fl.RPCHeaders.MD)
 	resp, err := healthpb.NewHealthClient(conn).Check(rpcCtx,
 		&healthpb.HealthCheckRequest{
-			Service: flService})
+			Service: fl.Service})
 	if err != nil {
 		if stat, ok := status.FromError(err); ok && stat.Code() == codes.Unimplemented {
 			log.Printf("error: this server does not implement the grpc health protocol (grpc.health.v1.Health): %s", stat.Message())
 		} else if stat, ok := status.FromError(err); ok && stat.Code() == codes.DeadlineExceeded {
-			log.Printf("timeout: health rpc did not complete within %v", flRPCTimeout)
+			log.Printf("timeout: health rpc did not complete within %v", fl.RPCTimeout)
 		} else {
 			log.Printf("error: health rpc failed: %+v", err)
 		}
-		retcode = StatusRPCFailure
-		return
+		return StatusRPCFailure
 	}
 	rpcDuration := time.Since(rpcStart)
 
 	if resp.GetStatus() != healthpb.HealthCheckResponse_SERVING {
 		log.Printf("service unhealthy (responded with %q)", resp.GetStatus().String())
-		retcode = StatusUnhealthy
-		return
+		return StatusUnhealthy
 	}
-	if flVerbose {
+	if fl.Verbose {
 		log.Printf("time elapsed: connect=%v rpc=%v", connDuration, rpcDuration)
 	}
 	log.Printf("status: %v", resp.GetStatus().String())
+	return 0
+}
+
+func main() {
+	os.Exit(probe(os.Args[1:]...))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,8 @@ func startServing(t *testing.T, srv *grpc.Server) string {
 		t.Fatalf("failed to listen: %v", err)
 	}
 	go srv.Serve(lis)
+	// srv.Stop() closes the listener.
+	t.Cleanup(srv.Stop)
 	return lis.Addr().String()
 }
 
@@ -25,7 +27,6 @@ func TestHealthProbe(t *testing.T) {
 	srv := grpc.NewServer()
 	grpc_health_v1.RegisterHealthServer(srv, health.NewServer())
 	addr := startServing(t, srv)
-	defer srv.Stop()
 
 	retcode := probe("-addr=" + addr)
 	if retcode != 0 {
@@ -36,7 +37,6 @@ func TestHealthProbe(t *testing.T) {
 func TestHealthProbeUnimplemented(t *testing.T) {
 	srv := grpc.NewServer()
 	addr := startServing(t, srv)
-	defer srv.Stop()
 
 	retcode := probe("-addr=" + addr)
 	if retcode != StatusRPCFailure {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"net"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// startServing runs the gRPC server in a goroutine and returns the addr to
+// connect on.
+func startServing(t *testing.T, srv *grpc.Server) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	go srv.Serve(lis)
+	return lis.Addr().String()
+}
+
+func TestHealthProbe(t *testing.T) {
+	srv := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(srv, health.NewServer())
+	addr := startServing(t, srv)
+	defer srv.Stop()
+
+	retcode := probe("-addr=" + addr)
+	if retcode != 0 {
+		t.Errorf("probe -addr=%s returned %d, want 0", addr, retcode)
+	}
+}
+
+func TestHealthProbeUnimplemented(t *testing.T) {
+	srv := grpc.NewServer()
+	addr := startServing(t, srv)
+	defer srv.Stop()
+
+	retcode := probe("-addr=" + addr)
+	if retcode != StatusRPCFailure {
+		t.Errorf("probe -addr=%s returned %d, want 0", addr, retcode)
+	}
+}


### PR DESCRIPTION
Since a lot of the logic is in the flag parsing and return code
generation, it seems worth including it in the test, which requires a
bit of a refactor.

I'm afraid I don't know enough about GitHub actions to guess if this will run as part of ci.yml, but let me know if I should add `go test -v .` there or if it's unnecessary.