### PR TITLE
Add darwin builds + linux container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.17
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16
+        go-version: 1.17
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 )
 
-go 1.15
+go 1.17


### PR DESCRIPTION
Adding darwin/{amd64,arm64} builds for releases.

Adding container image (via ghcr.io) tagged and pushed on each
release, containing a single binary. Currently only for linux/amd64.