### PR TITLE
Added multiarch container image supporting all the architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
 jobs:
-  goreleaser:
+  ci:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,25 +20,96 @@ jobs:
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload binaries artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: multi-arch-binaries
+        path: |
+          ./dist/*
+
+  release-images:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+          - arch: arm64
+            platform: linux/arm64
+          - arch: arm_6
+            platform: linux/arm/v6
+          - arch: ppc64le
+            platform: linux/ppc64le
+          - arch: s390x
+            platform: linux/s390x
+          - arch: 386
+            platform: linux/386
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Downlaod binaries artifact
+      uses: actions/download-artifact@v2
+      with:
+        name: multi-arch-binaries
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push container image (linux/amd64)
+    - name: Build and push container image ${{ matrix.arch }}
       run: |
         set -euo pipefail
         tag="$(git describe --tag --always --dirty)"
         tar cv --owner=root:0 --group=root:0 --mtime='1970-01-01 00:00:00' \
-          --directory=dist/grpc-health-probe_linux_amd64 . |\
+          --directory=grpc-health-probe_linux_${{ matrix.arch }} . |\
             docker import \
               --change 'ENTRYPOINT ["/grpc_health_probe"]' \
               --change 'LABEL org.opencontainers.image.title="${{ github.repository }}"' \
               --change 'LABEL org.opencontainers.image.source="https://github.com/${{ github.repository }}"' \
               --change "LABEL org.opencontainers.image.version=${tag}" \
               --change 'LABEL org.opencontainers.image.revision="${{ github.sha }}"' \
-              --platform linux/amd64 \
-              - "ghcr.io/${{ github.repository }}:${tag}"
-        docker push "ghcr.io/${{ github.repository }}:${tag}"
+              --platform ${{ matrix.platform }} \
+              - "ghcr.io/${{ github.repository }}:${tag}-${{ matrix.arch }}"
+        docker push "ghcr.io/${{ github.repository }}:${tag}-${{ matrix.arch }}"
 
+  release-multiarch-manifest:
+    runs-on: ubuntu-latest
+    needs: release-images
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build multi-arch manifest
+      run: |
+        set -euo pipefail
+        tag="$(git describe --tag --always --dirty)"
+        docker manifest create \
+        ghcr.io/${{ github.repository }}:${tag} \
+        --amend ghcr.io/${{ github.repository }}:${tag}-amd64 \
+        --amend ghcr.io/${{ github.repository }}:${tag}-arm64 \
+        --amend ghcr.io/${{ github.repository }}:${tag}-ppc64le \
+        --amend ghcr.io/${{ github.repository }}:${tag}-s390x \
+        --amend ghcr.io/${{ github.repository }}:${tag}-386 \
+        --amend ghcr.io/${{ github.repository }}:${tag}-arm_6
+
+        # Annotate the architectures inside the manifest
+        docker manifest annotate --arch arm64 \
+        ghcr.io/${{ github.repository }}:${tag} ghcr.io/${{ github.repository }}:${tag}-arm64
+        docker manifest annotate --arch ppc64le \
+        ghcr.io/${{ github.repository }}:${tag} ghcr.io/${{ github.repository }}:${tag}-ppc64le
+        docker manifest annotate --arch s390x \
+        ghcr.io/${{ github.repository }}:${tag} ghcr.io/${{ github.repository }}:${tag}-s390x
+        docker manifest annotate --arch 386 \
+        ghcr.io/${{ github.repository }}:${tag} ghcr.io/${{ github.repository }}:${tag}-386
+        docker manifest annotate --arch arm \
+        ghcr.io/${{ github.repository }}:${tag} ghcr.io/${{ github.repository }}:${tag}-arm_6
+
+        # Push the manifest
+        docker manifest push ghcr.io/${{ github.repository }}:${tag}


### PR DESCRIPTION
Using the binaries already built by the goreleaser step we can build the multi-arch
container keeping the tags and labels.