### PR TITLE
add multi-arch images using ko

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
 jobs:
-  goreleaser:
+  ci:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     tags:
     - 'v*.*.*'
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -13,32 +13,23 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.17
-    - name: GoReleaser
+    - name: Setup ko
+      uses: imjasonh/setup-ko@v0.4
+      with:
+        version: v0.9.3
+    - name: Binary builds with GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:
         version: latest
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push container image (linux/amd64)
+    - name: Build and push multi-arch container images
       run: |
         set -euo pipefail
         tag="$(git describe --tag --always --dirty)"
-        tar cv --owner=root:0 --group=root:0 --mtime='1970-01-01 00:00:00' \
-          --directory=dist/grpc-health-probe_linux_amd64 . |\
-            docker import \
-              --change 'ENTRYPOINT ["/grpc_health_probe"]' \
-              --change 'LABEL org.opencontainers.image.title="${{ github.repository }}"' \
-              --change 'LABEL org.opencontainers.image.source="https://github.com/${{ github.repository }}"' \
-              --change "LABEL org.opencontainers.image.version=${tag}" \
-              --change 'LABEL org.opencontainers.image.revision="${{ github.sha }}"' \
-              --platform linux/amd64 \
-              - "ghcr.io/${{ github.repository }}:${tag}"
-        docker push "ghcr.io/${{ github.repository }}:${tag}"
-
+        export KO_DOCKER_REPO="ghcr.io/${{ github.repository }}"
+        export PATH="$(go env GOPATH)/bin:$PATH"
+        echo "${{ github.token }}" | ko login ghcr.io --username ignored --password-stdin
+        set -x
+        ko publish --bare --tags "$tag" --platform=all .

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,10 +4,8 @@ before:
 builds:
 - main: .
   binary: grpc_health_probe
-  flags:
-  - -tags=netgo
-  ldflags:
-  - -w
+  flags: ["-tags=netgo"] # sync changes to .ko.yml
+  ldflags: ["-w"]        # sync changes to .ko.yml
   env:
   - CGO_ENABLED=0
   goos:

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,4 @@
+builds:
+- id: grpc_health_probe
+  flags: ["-tags=netgo"] # sync changes to .goreleaser.yml
+  ldflags: ["-w"]        # sync changes to .goreleaser.yml


### PR DESCRIPTION
This is an alternative take to #86.
Fixes #85.

- Example multi-arch repo: https://github.com/ahmetb/grpc-health-probe/pkgs/container/grpc-health-probe/9380802?tag=v0.99.10
- Build output: https://github.com/ahmetb/grpc-health-probe/runs/4005113125?check_suite_focus=true

advantages:

* no Dockerfile
* multi-arch images can be built/pushed in one command.
* reproducible builds as they are timestamped to 0.

disadvantages:

* limited to os/arch combonatios supported on the base
  image (gcr.io/distroless/static:nonroot) and linux/386
  is currently not published on distroless.
* binaries are compiled twice
* produced binaries in GH releases vs container images
  are not identical (there's visible size diff, needs debugging)
* can't use OCI labels such as `org.opencontainers.image.source`
  but they are not critical as GitHub still associates them
  to the repo correctly and they probably will be supported in
  ko at some point.

PTAL @sxd @jzelinskie @mnencia 