### PR TITLE
Fix rpc-timeout not being used correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,7 +283,7 @@ func main() {
 	rpcStart := time.Now()
 	rpcCtx, rpcCancel := context.WithTimeout(ctx, flRPCTimeout)
 	defer rpcCancel()
-	rpcCtx = metadata.NewOutgoingContext(ctx, flRPCHeaders.MD)
+	rpcCtx = metadata.NewOutgoingContext(rpcCtx, flRPCHeaders.MD)
 	resp, err := healthpb.NewHealthClient(conn).Check(rpcCtx,
 		&healthpb.HealthCheckRequest{
 			Service: flService})


### PR DESCRIPTION
`rpcCtx` created with the `rcp-timeout` is being overwritten incorrectly by
the metadata context, making the timeout being ignored for the RPC call.