### PR TITLE
Bumping Go version to address CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: Setup ko
       uses: imjasonh/setup-ko@v0.4
       with:


### PR DESCRIPTION
Bumping go version to 1.19 to address the following CVEs
* [CVE-2022-41725](https://nvd.nist.gov/vuln/detail/CVE-2022-41725)
* [CVE-2022-41724](https://nvd.nist.gov/vuln/detail/CVE-2022-41724)
* [CVE-2022-41723](https://nvd.nist.gov/vuln/detail/CVE-2022-41723)