### PR TITLE
Add -version flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.20
+        go-version: '1.20'
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -183,7 +183,6 @@ a non-zero exit code.
 | **2** | failure: connection failed or timed out |
 | **3** | failure: rpc failed or timed out |
 | **4** | failure: rpc successful, but the response is not `SERVING` |
-| **5** | failure: service intentionally not checked, eg was run with `-version` |
 | **20** | failure: could not retrieve TLS credentials using the [SPIFFE Workload API][spiffe] |
 
 ----

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ environment variable.
 | **`-user-agent`** | user-agent header value of health check requests (default: grpc_health_probe) |
 | **`-service`** | service name to check (default: "") - empty string is convention for server health |
 | **`-gzip`** | use GZIPCompressor for requests and GZIPDecompressor for response (default: false) |
+| **`-version`** | print the probe version and exit |
 
 **Example:**
 
@@ -182,6 +183,7 @@ a non-zero exit code.
 | **2** | failure: connection failed or timed out |
 | **3** | failure: rpc failed or timed out |
 | **4** | failure: rpc successful, but the response is not `SERVING` |
+| **5** | failure: service intentionally not checked, eg was run with `-version` |
 | **20** | failure: could not retrieve TLS credentials using the [SPIFFE Workload API][spiffe] |
 
 ----

--- a/main.go
+++ b/main.go
@@ -216,21 +216,20 @@ func buildCredentials(skipVerify bool, caCerts, clientCert, clientKey, serverNam
 
 func probeVersion() string {
 	version := "vcs info was not included in build"
+	dirty := ""
 
-	vcsDetails := map[string]string{"vcs.revision": "", "vcs.modified": ""}
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
-			if _, ok := vcsDetails[setting.Key]; ok {
-				vcsDetails[setting.Key] = setting.Value
+
+			switch setting.Key {
+			case "vcs.revision":
+				version = setting.Value
+			case "vcs.modified":
+			        dirty = setting.Value
 			}
 		}
 	}
-	if vcsDetails["vcs.revision"] == "" {
-		return version
-	}
-
-	version = "commit " + vcsDetails["vcs.revision"]
-	if vcsDetails["vcs.modified"] == "true" {
+	if dirty == "true" {
 		version = version + " (dirty)"
 	}
 	return version

--- a/main.go
+++ b/main.go
@@ -68,8 +68,6 @@ const (
 	StatusRPCFailure = 3
 	// StatusUnhealthy indicates rpc succeeded but indicates unhealthy service.
 	StatusUnhealthy = 4
-	// StatusNotChecked indicates service status was intentionally not checked.
-	StatusNotChecked = 5
 	// StatusSpiffeFailed indicates failure to retrieve credentials using spiffe workload API
 	StatusSpiffeFailed = 20
 )
@@ -108,8 +106,8 @@ func init() {
 	}
 
 	if flVersion {
-		log.Println(probeVersion())
-		os.Exit(StatusNotChecked)
+		fmt.Println(probeVersion())
+		os.Exit(0)
 	}
 
 	if flAddr == "" {
@@ -219,7 +217,7 @@ func buildCredentials(skipVerify bool, caCerts, clientCert, clientKey, serverNam
 func probeVersion() string {
 	version := "vcs info was not included in build"
 
-	vcsDetails := map[string]string{"vcs": "", "vcs.revision": "", "vcs.time": "", "vcs.modified": ""}
+	vcsDetails := map[string]string{"vcs.revision": "", "vcs.modified": ""}
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {
 			if _, ok := vcsDetails[setting.Key]; ok {
@@ -227,16 +225,13 @@ func probeVersion() string {
 			}
 		}
 	}
-	if vcsDetails["vcs"] == "" {
+	if vcsDetails["vcs.revision"] == "" {
 		return version
 	}
 
-	version = strings.Join(
-		[]string{vcsDetails["vcs"], vcsDetails["vcs.revision"], vcsDetails["vcs.time"]},
-		" ",
-	)
+	version = "commit " + vcsDetails["vcs.revision"]
 	if vcsDetails["vcs.modified"] == "true" {
-		version = version + " (built with changes outside version control)"
+		version = version + " (dirty)"
 	}
 	return version
 }

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func probeVersion() string {
 
 			switch setting.Key {
 			case "vcs.revision":
-				version = setting.Value
+				version = "commit " + setting.Value
 			case "vcs.modified":
 			        dirty = setting.Value
 			}

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func probeVersion() string {
 			case "vcs.revision":
 				version = "commit " + setting.Value
 			case "vcs.modified":
-			        dirty = setting.Value
+				dirty = setting.Value
 			}
 		}
 	}


### PR DESCRIPTION
Added `-version` flag.  Exits non-zero so accidentally running with this flag will not indicate a service is up. 

Typical output:
```
$ ./grpc-health-probe -version
git b35a00f4192e0a0654c9e1ff6e7400513e2d000a 2023-06-13T04:13:12Z
```

When built when there are local changes not checked into Git:
```
$ ./grpc-health-probe -version
git 1089f40639043ee46cc47cbea1bcb0cc48cfc284 2023-06-12T16:41:19Z (built with changes outside version control)
```

When not built with VCS information:
```
$ go run main.go -version
vcs info was not included in build
exit status 5
```

Note, Go does not include the Git tag in the build information included in the executable.  If we want to do something like that, in the past I have had a build job run a script that runs `git` commands and writes the output into strings in a `.go` file that gets included in the build.

Fixes #14.