### PR TITLE
Fix dirty build flag in release binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ out/
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# goreleaser artefacts
+dist/


### PR DESCRIPTION
fixes #159 

tested locally by running 
````
goreleaser release --snapshot --clean
````
before and after aplying this change:

<details>

<summary>before</summary>

````bash
~/grpc-health-probe|fix-drity-build ⇒  git checkout master                                     
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
~/grpc-health-probe|master⚡ ⇒  goreleaser release --snapshot --clean                         
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=992bb35f76c2b7f3835ccbdafdbe77527717c9a1 latest tag=v0.4.21
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
  • snapshotting
    • building snapshot...                           version=0.4.21-SNAPSHOT-992bb35
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/grpc-health-probe_linux_arm64/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_darwin_arm64/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_amd64_v1/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_darwin_amd64_v1/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_arm_6/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_386/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_ppc64le/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_s390x/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_windows_arm64/grpc_health_probe.exe
    • building                                       binary=dist/grpc-health-probe_windows_amd64_v1/grpc_health_probe.exe
    • took: 2s
  • archives
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-ppc64le
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-arm
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-s390x
    • skip archiving                                 binary=grpc_health_probe.exe name=grpc_health_probe-windows-amd64.exe
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-amd64
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-darwin-arm64
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-386
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-darwin-amd64
    • skip archiving                                 binary=grpc_health_probe.exe name=grpc_health_probe-windows-arm64.exe
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-arm64
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 2s
  • thanks for using goreleaser!
~/grpc-health-probe|master⚡ ⇒  dist/grpc-health-probe_darwin_arm64/grpc_health_probe -version
commit 992bb35f76c2b7f3835ccbdafdbe77527717c9a1 (dirty)
````
</details>

<details> 

<summary>after</summary>

````bash
~/grpc-health-probe|master⚡ ⇒  git checkout fix-drity-build 
Switched to branch 'fix-drity-build'
Your branch is up to date with 'origin/fix-drity-build'.
stefanb@MBP14:~/Documents/GitHub/grpc-health-probe|fix-drity-build ⇒  goreleaser release --snapshot --clean                         
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=1a6cbf96028a7a9f74020db8dc96ed0e2ce5d003 latest tag=v0.4.21
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
  • snapshotting
    • building snapshot...                           version=0.4.21-SNAPSHOT-1a6cbf9
  • checking distribution directory
    • cleaning dist
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/grpc-health-probe_darwin_arm64/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_arm_6/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_arm64/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_ppc64le/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_s390x/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_386/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_linux_amd64_v1/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_darwin_amd64_v1/grpc_health_probe
    • building                                       binary=dist/grpc-health-probe_windows_amd64_v1/grpc_health_probe.exe
    • building                                       binary=dist/grpc-health-probe_windows_arm64/grpc_health_probe.exe
    • took: 2s
  • archives
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-arm64
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-s390x
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-386
    • skip archiving                                 binary=grpc_health_probe.exe name=grpc_health_probe-windows-arm64.exe
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-darwin-amd64
    • skip archiving                                 binary=grpc_health_probe.exe name=grpc_health_probe-windows-amd64.exe
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-amd64
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-ppc64le
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-darwin-arm64
    • skip archiving                                 binary=grpc_health_probe name=grpc_health_probe-linux-arm
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 2s
  • thanks for using goreleaser!
~/grpc-health-probe|fix-drity-build ⇒  dist/grpc-health-probe_darwin_arm64/grpc_health_probe -version
commit 1a6cbf96028a7a9f74020db8dc96ed0e2ce5d003
````
</details>