### PR TITLE
Add semantic version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push multi-arch container images
+      env:
+        VERSION_TAG: ${GITHUB_REF_NAME#v}
       run: |
         set -euo pipefail
         tag="$(git describe --tag --always --dirty)"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ builds:
 - main: .
   binary: grpc_health_probe
   flags: ["-tags=netgo"] # sync changes to .ko.yml
-  ldflags: ["-w"]        # sync changes to .ko.yml
+  ldflags: ["-w -X main.versionTag={{.Version}}"] # sync changes to .ko.yml
   env:
   - CGO_ENABLED=0
   goos:

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
 builds:
 - id: grpc_health_probe
   flags: ["-tags=netgo"] # sync changes to .goreleaser.yml
-  ldflags: ["-w"]        # sync changes to .goreleaser.yml
+  ldflags: ["-w -X main.versionTag={{.Env.VERSION_TAG}}"] # sync changes to .goreleaser.yml

--- a/main.go
+++ b/main.go
@@ -214,6 +214,8 @@ func buildCredentials(skipVerify bool, caCerts, clientCert, clientKey, serverNam
 	return credentials.NewTLS(&cfg), nil
 }
 
+var versionTag = "" // set from git tag via ldflags during build
+
 func probeVersion() string {
 	version := "vcs info was not included in build"
 	dirty := ""
@@ -231,6 +233,10 @@ func probeVersion() string {
 	}
 	if dirty == "true" {
 		version = version + " (dirty)"
+	}
+
+	if versionTag != "" {
+		version = fmt.Sprintf("%s; %s", versionTag, version)
 	}
 	return version
 }


### PR DESCRIPTION
Improves upon #146 to include the semantic version number from git tag.