### PR TITLE
Fix missing changelog entries on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
+      with:
+        fetch-depth: 0
     - name: Setup Go
       uses: actions/setup-go@v1
       with:


### PR DESCRIPTION
Recent releases https://github.com/grpc-ecosystem/grpc-health-probe/releases are misleading, because they are erroneously only listing the one latest change of the last commit, often just some chore task after more significant changes.

Goreleaser requires full git history to generate full changelog.

See
* https://goreleaser.com/errors/no-history/
* https://goreleaser.com/ci/actions/

Please consider manually changing or generating release notes for at least few recent releases or adding compare links.