### PR TITLE
Updates binary name to comply with the go install command resulted name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ success, otherwise it will exit with a non-zero exit code (documented below).
 **EXAMPLES**
 
 ```text
-$ grpc_health_probe -addr=localhost:5000
+$ grpc-health-probe -addr=localhost:5000
 healthy: SERVING
 ```
 
 ```text
-$ grpc_health_probe -addr=localhost:9999 -connect-timeout 250ms -rpc-timeout 100ms
+$ grpc-health-probe -addr=localhost:9999 -connect-timeout 250ms -rpc-timeout 100ms
 failed to connect service at "localhost:9999": context deadline exceeded
 exit status 2
 ```
@@ -161,7 +161,7 @@ environment variable.
    [cert](https://github.com/grpc/grpc-go/blob/be59908d40f00be3573a50284c3863f1a37b8528/testdata/server1.pem) is signed for:
 
       ```sh
-      $ grpc_health_probe -addr 127.0.0.1:10000 \
+      $ grpc-health-probe -addr 127.0.0.1:10000 \
           -tls \
           -tls-ca-cert /path/to/testdata/ca.pem \
           -tls-server-name=example.com \

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ success, otherwise it will exit with a non-zero exit code (documented below).
 **EXAMPLES**
 
 ```text
-$ grpc-health-probe -addr=localhost:5000
+$ grpc_health_probe -addr=localhost:5000
 healthy: SERVING
 ```
 
 ```text
-$ grpc-health-probe -addr=localhost:9999 -connect-timeout 250ms -rpc-timeout 100ms
+$ grpc_health_probe -addr=localhost:9999 -connect-timeout 250ms -rpc-timeout 100ms
 failed to connect service at "localhost:9999": context deadline exceeded
 exit status 2
 ```
@@ -161,7 +161,7 @@ environment variable.
    [cert](https://github.com/grpc/grpc-go/blob/be59908d40f00be3573a50284c3863f1a37b8528/testdata/server1.pem) is signed for:
 
       ```sh
-      $ grpc-health-probe -addr 127.0.0.1:10000 \
+      $ grpc_health_probe -addr 127.0.0.1:10000 \
           -tls \
           -tls-ca-cert /path/to/testdata/ca.pem \
           -tls-server-name=example.com \

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grpc-ecosystem/grpc-health-probe
+module github.com/grpc-ecosystem/grpc_health_probe
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.1.6


### PR DESCRIPTION
This Pull Request has a quite simple contribution.

When you install using `go install github.com/grpc-ecosystem/grpc-health-probe@latest`
the binary name is actually `grpc-health-probe` instead of `grpc_health_probe` as described in the README.md file.

Thus, this pull request simply updates the binary name in the README.md documentation file. 

**What problem does it solve?**
Basically when a developer follows this documentation, they end up trying to run a command that does not
exist in GOPATH. Since the binary name indeed does not exists, eventually, some developer can abort using
the tool simply because it could not install it. Basically the binary is there, but the name is incorrect. 