### PR TITLE
Update README.md to Notify About Native Cluster Support for GRPC Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # You may not need that anymore
 
-Since version 1.24, Kubernetes provided native support for GRPC health checks.
+Since version 1.24, Kubernetes provided [native support for GRPC health checks]( https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe).
 
 ```yaml
           livenessProbe:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# You may not need that anymore
+
+Since version 1.24, Kubernetes provided native support for GRPC health checks.
+
+```yaml
+          livenessProbe:
+            initialDelaySeconds: 10
+            grpc:
+              port: 5000 # service GRPC port
+          readinessProbe:
+            initialDelaySeconds: 5
+            grpc:
+              port: 5000 # service GRPC port
+```
+
 # grpc_health_probe(1)
 
 ![ci](https://github.com/grpc-ecosystem/grpc-health-probe/workflows/ci/badge.svg)


### PR DESCRIPTION
I've added a note about the native support for GRPC health check, which makes installing this not required for updated clusters.