### PR TITLE
Auto-tag commits on master

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,50 @@
+name: Tag patch release
+
+on:
+  push:
+    branches:
+      - master  # Adjust to match the name of your main branch
+    paths-ignore:
+      - .github/**
+      - README.md
+      - LICENSE
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Important to fetch all tags and history
+
+      # Determine the new version number
+      - name: Get latest tag and increment
+        id: versioning
+        run: |
+          # Fetch all tags
+          git fetch --tags
+
+          # Get the highest tag number, and add 1 to the patch
+          TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+          echo "Current highest tag is $TAG"
+
+          # Increment the patch version
+          NEW_TAG="${TAG%.*}.$((${TAG##*.}+1))"
+          echo "New tag will be $NEW_TAG"
+
+          # Set NEW_TAG as an output variable
+          echo "NEW_VERSION=$NEW_TAG" >> $GITHUB_ENV
+
+      # Create a new tag
+      - name: Create Git tag for PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{env.NEW_VERSION}}",
+              sha: context.sha
+            })


### PR DESCRIPTION
This will automatically bump a patch version every time we merge a commit into master. Then goreleaser will prepare a release for the tag.