### PR TITLE
Sync golang upgrade to 1.23 to all other files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
     - name: Setup ko
       uses: imjasonh/setup-ko@v0.7
       with:

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 )
 
-go 1.22
+go 1.23


### PR DESCRIPTION
The CVE is already fixed in the latest version, 0.4.34. This proliferates the go version found in the Dockerfile of 1.23 to the other parts of the repo like go.mod, and the github CI files.