### PR TITLE
Updated deprecated goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
   - go mod download
@@ -28,5 +29,5 @@ checksum:
   name_template: "checksums.txt"
   algorithm: sha256
 archives:
-  - format: binary
+  - formats: [ binary ]
     name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
Noticed the warnings in action logs.

Before:
```
$ goreleaser check
  • only  version: 2  configuration files are supported, yours is  version: 0 , please update your configuration
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```

After:
```
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
```