### PR TITLE
Move ko container image builds to goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,18 @@ name: ci
 on:
   push:
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@master
+      with:
+        persist-credentials: false
     - name: Setup Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v6
       with:
         version: latest
-        args: release --snapshot --clean 
+        args: release --snapshot --clean --skip ko
+      env:
+        KO_DOCKER_REPO: "dummy"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
     - 'v*.*.*'
+
+permissions: 
+  contents: write
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -11,6 +16,7 @@ jobs:
       uses: actions/checkout@master
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Setup Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,14 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.24'
-    - name: Setup ko
-      uses: ko-build/setup-ko@v0.9
+
+    - name: Container registry login
+      uses: docker/login-action@v3
       with:
-        version: v0.17.1
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Binary builds with GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:
@@ -26,14 +30,4 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push multi-arch container images
-      env:
-        VERSION_TAG: ${GITHUB_REF_NAME#v}
-      run: |
-        set -euo pipefail
-        tag="$(git describe --tag --always --dirty)"
-        export KO_DOCKER_REPO="ghcr.io/${{ github.repository }}"
-        export PATH="$(go env GOPATH)/bin:$PATH"
-        echo "${{ github.token }}" | ko login ghcr.io --username ignored --password-stdin
-        set -x
-        ko publish --bare --tags "$tag" --platform=all .
+        KO_DOCKER_REPO: "ghcr.io/${{ github.repository }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,6 @@ jobs:
       with:
         go-version: '1.24'
 
-    - name: Container registry login
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Binary builds with GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '1.24'
+        cache: false
 
     - name: Binary builds with GoReleaser
       uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ kos:  # See https://goreleaser.com/customization/ko/
 
 release:
   footer: >-
-    **Container Image**: `ghcr.io/stefanb/grpc-health-probe:{{ .Version }}`
+    **Container Image**: `{{ .Env.KO_DOCKER_REPO }}:{{ .Version }}`
 
     **Full Changelog**: https://github.com/grpc-ecosystem/grpc-health-probe/compare/{{ .PreviousTag }}...{{ .Tag }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,8 +40,6 @@ kos:  # See https://goreleaser.com/customization/ko/
     - ghcr.io/stefanb/grpc-health-probe
     tags:
     - '{{.Version}}'
-    - '{{ .Major }}.{{ .Minor }}'
-    - latest
     bare: true
     preserve_import_paths: false
     platforms:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,8 +51,8 @@ kos:  # See https://goreleaser.com/customization/ko/
     - linux/riscv64
 
 release:
-  footer: >-
-    **Container Image**: `{{ .Env.KO_DOCKER_REPO }}:{{ .Version }}`
+  footer: |
+    **Container Image** in [{{ .Env.KO_DOCKER_REPO }}](https://{{ .Env.KO_DOCKER_REPO }}): `{{ .Env.KO_DOCKER_REPO }}:{{ .Version }}`
 
     **Full Changelog**: https://github.com/grpc-ecosystem/grpc-health-probe/compare/{{ .PreviousTag }}...{{ .Tag }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,7 +37,7 @@ archives:
 
 kos:  # See https://goreleaser.com/customization/ko/
   - tags:
-    - '{{.Version}}'
+    - '{{.Tag}}'
     bare: true
     preserve_import_paths: false
     base_image: "gcr.io/distroless/static:nonroot"
@@ -50,7 +50,7 @@ kos:  # See https://goreleaser.com/customization/ko/
 
 release:
   footer: |
-    **Container Image** in [{{ .Env.KO_DOCKER_REPO }}](https://{{ .Env.KO_DOCKER_REPO }}): `{{ .Env.KO_DOCKER_REPO }}:{{ .Version }}`
+    **Container Image** in [{{ .Env.KO_DOCKER_REPO }}](https://{{ .Env.KO_DOCKER_REPO }}): `{{ .Env.KO_DOCKER_REPO }}:{{ .Tag }}`
 
     **Full Changelog**: https://github.com/grpc-ecosystem/grpc-health-probe/compare/{{ .PreviousTag }}...{{ .Tag }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ kos:  # See https://goreleaser.com/customization/ko/
 
 release:
   footer: >-
-    **Container Image**: `ghcr.io/stefanb/grpc-health-probe:{{ .Tag }}`
+    **Container Image**: `ghcr.io/stefanb/grpc-health-probe:{{ .Version }}`
 
     **Full Changelog**: https://github.com/grpc-ecosystem/grpc-health-probe/compare/{{ .PreviousTag }}...{{ .Tag }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,8 +34,20 @@ checksum:
 archives:
   - formats: [ binary ]
     name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
+
+kos:  # See https://goreleaser.com/customization/ko/
+  - repositories:
+    - ghcr.io/stefanb/grpc-health-probe
+    tags:
+    - '{{.Version}}'
+    bare: true
+    preserve_import_paths: false
+    platforms:
+    - linux/amd64
+
 release:
   footer: >-
+    **Container Image**: `ghcr.io/stefanb/grpc-health-probe:{{ .Tag }}`
 
     **Full Changelog**: https://github.com/grpc-ecosystem/grpc-health-probe/compare/{{ .PreviousTag }}...{{ .Tag }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,7 @@ kos:  # See https://goreleaser.com/customization/ko/
     - '{{.Version}}'
     bare: true
     preserve_import_paths: false
+    base_image: "gcr.io/distroless/static:nonroot"
     platforms:
     - linux/386
     - linux/amd64

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,10 +40,18 @@ kos:  # See https://goreleaser.com/customization/ko/
     - ghcr.io/stefanb/grpc-health-probe
     tags:
     - '{{.Version}}'
+    - '{{ .Major }}.{{ .Minor }}'
+    - latest
     bare: true
     preserve_import_paths: false
     platforms:
+    - linux/386
     - linux/amd64
+    - linux/arm/v7
+    - linux/arm64/v8
+    - linux/ppc64le
+    - linux/s390x
+    - linux/riscv64
 
 release:
   footer: >-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,13 +42,11 @@ kos:  # See https://goreleaser.com/customization/ko/
     preserve_import_paths: false
     base_image: "gcr.io/distroless/static:nonroot"
     platforms:
-    - linux/386
     - linux/amd64
     - linux/arm/v7
     - linux/arm64/v8
     - linux/ppc64le
     - linux/s390x
-    - linux/riscv64
 
 release:
   footer: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,9 +36,7 @@ archives:
     name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
 
 kos:  # See https://goreleaser.com/customization/ko/
-  - repositories:
-    - ghcr.io/stefanb/grpc-health-probe
-    tags:
+  - tags:
     - '{{.Version}}'
     bare: true
     preserve_import_paths: false

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,0 @@
-defaultBaseImage: gcr.io/distroless/static
-builds:
-- id: grpc_health_probe
-  flags: ["-tags=netgo"] # sync changes to .goreleaser.yml
-  ldflags: ["-w -X main.versionTag={{.Env.VERSION_TAG}}"] # sync changes to .goreleaser.yml


### PR DESCRIPTION
* Use https://goreleaser.com/customization/ko/ instead of additional github action and a separate config file.
* Same platforms as before.
* Base image changed from `gcr.io/distroless/static` to `gcr.io/distroless/static:nonroot` as there should be no need for root privileges.
* ~Added mutable `latest` tag to released image to ease referencing it. Question for @ahmetb: Do we want to keep that?~ REVERTED
* Software bill of material ([SBOM](https://www.cisa.gov/sbom)) published in [SPDX](https://spdx.dev/) format along with container images
* Tighter workflow permissions
* Disabled Go build cache for releases

Test release in my fork:
* https://github.com/stefanb/grpc-health-probe/releases/tag/v0.4.39-stefanb-dev11
* https://ghcr.io/stefanb/grpc-health-probe (compare it with https://ghcr.io/grpc-ecosystem/grpc-health-probe )

