### PR TITLE
docs: Improve Dockerfile installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,15 @@ You can bundle the statically compiled `grpc_health_probe` in your container
 image. Choose a [binary release][rel] and download it in your Dockerfile:
 
 ```bash
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.13 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+RUN GRPC_HEALTH_PROBE_VERSION=v0.4.38 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
     chmod +x /bin/grpc_health_probe
+```
+
+or via release image:
+
+```dockerfile
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.38 /ko-app/grpc-health-probe /bin/grpc_health_probe
 ```
 
 In your Kubernetes Pod specification manifest, specify a `livenessProbe` and/or

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can bundle the statically compiled `grpc_health_probe` in your container
 image. Choose a [binary release][rel] and download it in your Dockerfile:
 
 ```bash
+ARG TARGETOS TARGETARCH
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.38 && \
     wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-${TARGETOS}-${TARGETARCH} && \
     chmod +x /bin/grpc_health_probe


### PR DESCRIPTION
* Use `TARGETOS` & `TARGETARCH` implicit variables to choose correct release binary for any supported target ([docs](https://docs.docker.com/build/building/variables/#multi-platform-build-arguments))
* Added a simpler option to `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.38` ([docs](https://docs.docker.com/reference/dockerfile/#copy))