### PR TITLE
ci: use Go from toolchain directive, bump Go to 1.24.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
         cache: false
 
     - name: Binary builds with GoReleaser

--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,4 @@ require (
 
 go 1.23.0
 
-toolchain go1.24.4
+toolchain go1.24.7


### PR DESCRIPTION
* CI workflows: upgrade setup-go action to v6 https://github.com/actions/setup-go/releases/tag/v6.0.0 to make use https://github.com/actions/setup-go/pull/460 to specify Go version for development and CI pipelines in a single place (`go.mod` file).
* Bumped Go toolchain from 1.24.4 to 1.24.7 for security fixes of CVE-2025-4674, CVE-2025-47906, CVE-2025-47907 (false positive #267) after a release