### PR TITLE
Bump Go toolchain from 1.24.7 to 1.24.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,4 +20,4 @@ require (
 
 go 1.23.0
 
-toolchain go1.24.7
+toolchain go1.24.8


### PR DESCRIPTION
Go 1.24.8 has security updates:
https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI
