### PR TITLE
Bump Go toolchain from 1.25.8 to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.24 AS build
-ENV PROJECT grpc_health_probe
+FROM golang:1.25 AS build
+ENV PROJECT=grpc_health_probe
 WORKDIR /src/$PROJECT
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 ENV PROJECT=grpc_health_probe
 WORKDIR /src/$PROJECT
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grpc-ecosystem/grpc-health-probe
 
 go 1.24.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grpc-ecosystem/grpc-health-probe
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.26.2
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0


### PR DESCRIPTION
https://go.dev/doc/go1.26
https://go.dev/blog/go1.26
https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU
Fixing (among others):
CVE-2026-32282
CVE-2026-32289
CVE-2026-33810
CVE-2026-27144
CVE-2026-27143
CVE-2026-32288
CVE-2026-32283
CVE-2026-27140