### PR TITLE
Upgrade Go toolchain from 1.26.2 to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grpc-ecosystem/grpc-health-probe
 
 go 1.24.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/qcCIEXso47M

Go 1.26.3 fixes:
* CVE-2026-42501 / https://github.com/golang/go/issues/79070
- CVE-2026-39825 / https://github.com/golang/go/issues/78948
- CVE-2026-39836 / https://github.com/golang/go/issues/79006
- CVE-2026-42499 / https://github.com/golang/go/issues/78987
- CVE-2026-39820 / https://github.com/golang/go/issues/78566
- CVE-2026-39819 / https://github.com/golang/go/issues/78584
- CVE-2026-39817 / https://github.com/golang/go/issues/78778
- CVE-2026-33814 / https://github.com/golang/go/issues/78476
- CVE-2026-39826 / https://github.com/golang/go/issues/78981
- CVE-2026-33811 / https://github.com/golang/go/issues/78803
- CVE-2026-39823 / https://github.com/golang/go/issues/78913