### PR TITLE
Update Go toolchain 1.26.3 -> 1.26.4 for CVE-2026-42504, CVE-2026-42507 & CVE-2026-27145

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grpc-ecosystem/grpc-health-probe
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/tKs3rmcBcKw
* CVE-2026-42504 / https://github.com/golang/go/issues/79217
* CVE-2026-42507 / https://github.com/golang/go/issues/79346
* CVE-2026-27145 / https://github.com/golang/go/issues/79694