### PR TITLE
Add SIGTERM signal handling for Kubernetes pod shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"strings"
+	"syscall"
 	"time"
 	"unicode"
 
@@ -248,14 +249,11 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		sig := <-c
-		if sig == os.Interrupt {
-			log.Printf("cancellation received")
-			cancel()
-			return
-		}
+		log.Printf("cancellation received (signal: %v)", sig)
+		cancel()
 	}()
 
 	opts := []grpc.DialOption{


### PR DESCRIPTION
## Summary

Kubernetes sends `SIGTERM` (not `SIGINT`) when terminating pods. The signal handler previously only caught `os.Interrupt`, meaning the probe would not gracefully cancel in-flight RPCs on pod shutdown — it would only be hard-killed by `SIGKILL` after the grace period.

## Changes

- Add `syscall.SIGTERM` to `signal.Notify` alongside `os.Interrupt`
- Simplify the signal handler to cancel the context for any received signal (the previous `if sig == os.Interrupt` guard was unnecessary since only `os.Interrupt` was registered)
- Include the signal name in the cancellation log message for easier debugging