### PR TITLE
Update Go toolchain 1.26.4 -> 1.26.5 for CVE-2026-39822

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grpc-ecosystem/grpc-health-probe
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/spiffe/go-spiffe/v2 v2.8.1


### PR DESCRIPTION
Go 1.26.5 fixes CVE-2026-39822:
* https://groups.google.com/g/golang-announce/c/OrmQE_Yp5Sc
* https://github.com/golang/go/issues/79005